### PR TITLE
Run freeDiameterd with exec

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -43,4 +43,4 @@ fi
 [  -z "$DELAY_ENABLED" ] || sleep 10
 
 #RUN!!
-/usr/bin/freeDiameterd
+exec /usr/bin/freeDiameterd


### PR DESCRIPTION
This docker image isn't starting `freeDiameterd` as PID 1. This causes freeDiameter to miss signals since the bash script will receive those. You can see this when you execute `docker run tudorh/freediameter`, but you can't kill it with CTRL+C. 

This change fixes this, and causes the conatiner to be closed correctly when it has to be terminated.

For more information, see https://petermalmgren.com/signal-handling-docker/